### PR TITLE
fix: add rust-toolchain & remove hardcoded tld length

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ async fn main() {
         .flat_map(|file| {
             file.into_iter()
                 .map(|result| {
-                    let mut str = result[..result.len() - 2].to_owned();
+                    let mut str = result[..result.len() - TLD.len()].to_owned();
                     str.push_str(&format!(".{TLD}"));
                     str
                 })


### PR DESCRIPTION
This PR fixes a compilation error on systems using stable as their default Rust toolchain, and removes the hardcoded TLD length which allows searching of TLDs more than 2 characters long.